### PR TITLE
4-hours anticipations of cron jobs

### DIFF
--- a/jobs/clean-up/qa/values.yaml
+++ b/jobs/clean-up/qa/values.yaml
@@ -5,7 +5,7 @@ configmap:
   API_OPERATIONS_BASEURL: "http://tracing-be-operations.qa:8080"
 
 cronjob:
-  schedule: "50 23 * * *"
+  schedule: "50 19 * * *"
   timeZone: "Europe/Rome"
   concurrencyPolicy: "Forbid"
   activeDeadlineSeconds: 3600

--- a/jobs/missing-data-checker/qa/values.yaml
+++ b/jobs/missing-data-checker/qa/values.yaml
@@ -6,7 +6,7 @@ configmap:
   DAYS_OFFSET_FROM_TODAY: "1"
 
 cronjob:
-  schedule: "50 23 * * *"
+  schedule: "50 19 * * *"
   timeZone: "Europe/Rome"
   concurrencyPolicy: "Forbid"
   activeDeadlineSeconds: 3600


### PR DESCRIPTION
This PR updates QA Helm values to run two CronJobs 4 hours earlier (from 23:50 to 19:50) in the configured `Europe/Rome` time zone.

**Changes:**
- Adjust `jobs/missing-data-checker` QA CronJob schedule from `50 23 * * *` to `50 19 * * *`.
- Adjust `jobs/clean-up` QA CronJob schedule from `50 23 * * *` to `50 19 * * *`.
