### PR TITLE
chore: add QA nightly shotdown from 20 to 8 Europe/Rome timezone

### DIFF
--- a/commons/qa/values-microservice.yaml
+++ b/commons/qa/values-microservice.yaml
@@ -17,3 +17,16 @@ deployment:
     limits:
       cpu: "1"
       memory: "2Gi"
+
+autoscaling:
+  keda:
+    create: true
+    minReplicaCount: 0
+    maxReplicaCount: 1
+    triggers:
+    - type: cron
+      metadata:
+        timezone: Europe/Rome
+        start: 0 8 * * 1-5
+        end: 0 20 * * 1-5
+        desiredReplicas: "1" # must be a string


### PR DESCRIPTION

This PR updates the QA Helm values for microservices to add KEDA-based cron autoscaling, allowing the workload to scale to zero outside business hours in the Europe/Rome timezone.

**Changes:**
- Added an `autoscaling.keda` block to enable KEDA for QA.
- Configured a cron trigger to run at 1 replica between 08:00–20:00 (Mon–Fri), with `minReplicaCount: 0` outside that window.



